### PR TITLE
Prevent loosing sols by running simulations for the liquidations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "chrono",
         "Datasize",
         "grpf",
+        "liquidable",
         "nonblocking",
         "Oneof",
         "pdas",

--- a/src/client.rs
+++ b/src/client.rs
@@ -53,7 +53,7 @@ pub mod utils;
 const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:10000";
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-const MEAN_PRIORITY_FEE_PERCENTILE: u64 = 7500; // 75th
+const MEAN_PRIORITY_FEE_PERCENTILE: u64 = 5500; // 55th
 const PRIORITY_FEE_REFRESH_INTERVAL: Duration = Duration::from_secs(5); // seconds
 pub const CLOSE_POSITION_LONG_CU_LIMIT: u32 = 380_000;
 pub const CLOSE_POSITION_SHORT_CU_LIMIT: u32 = 280_000;

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -3,9 +3,9 @@ use {
         handlers::create_liquidate_long_ix, IndexedCustodiesThreadSafe, LIQUIDATE_LONG_CU_LIMIT,
     },
     adrena_abi::{
-        liquidation_price::get_liquidation_price, main_pool::USDC_CUSTODY_ID,
-        oracle_price::OraclePrice, types::Cortex, Custody, Position, ADX_MINT, ALP_MINT,
-        SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody,
+        LeverageCheckStatus, Pool, Position, ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID,
+        SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -96,7 +96,6 @@ pub async fn liquidate_long(
         _ => None,
     };
 
-    let rpc_client = program.rpc();
     let transfer_authority_pda = adrena_abi::pda::get_transfer_authority_pda().0;
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
@@ -120,6 +119,7 @@ pub async fn liquidate_long(
     )
     .await?;
 
+    let rpc_client = program.rpc();
     let mut simulation_attempts = 0;
     let simulation = loop {
         match rpc_client.simulate_transaction(&tx_simulation).await {

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -8,6 +8,7 @@ use {
         SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
+    chrono::Utc,
     solana_client::rpc_config::RpcSendTransactionConfig,
     solana_sdk::{
         compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
@@ -26,8 +27,7 @@ pub async fn liquidate_long(
     pool: &Pool,
     median_priority_fee: u64,
 ) -> Result<(), backoff::Error<anyhow::Error>> {
-    let current_time = chrono::Utc::now().timestamp();
-    
+    let start_time = Utc::now();
 
     let indexed_custodies_read = indexed_custodies.read().await;
     let custody = indexed_custodies_read.get(&position.custody).unwrap();
@@ -195,10 +195,13 @@ pub async fn liquidate_long(
             backoff::Error::transient(e.into())
         })?;
 
+    let end_time = Utc::now();
+    let duration = end_time - start_time;
     log::info!(
-        "   <> Liquidated Long position {:#?} - TX sent: {:#?}",
+        "   <> Liquidated Long position {:#?} - TX sent: {:#?} - (Took: {} ms)",
         position_key,
         tx_hash.to_string(),
+        duration.num_milliseconds()
     );
 
     Ok(())

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -27,6 +27,7 @@ pub async fn liquidate_long(
     median_priority_fee: u64,
 ) -> Result<(), backoff::Error<anyhow::Error>> {
     let current_time = chrono::Utc::now().timestamp();
+    
 
     let indexed_custodies_read = indexed_custodies.read().await;
     let custody = indexed_custodies_read.get(&position.custody).unwrap();

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -132,7 +132,6 @@ pub async fn liquidate_long(
                         simulation_attempts,
                         e
                     );
-                    // tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -39,7 +39,7 @@ pub async fn liquidate_long(
         &custody,
         &oracle_price,
         &custody,
-        current_time,
+        Utc::now().timestamp(),
         false,
     )?;
 

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -131,7 +131,7 @@ pub async fn liquidate_long(
                         simulation_attempts,
                         e
                     );
-                    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+                    // tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -114,8 +114,18 @@ pub async fn liquidate_long(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been liquidated by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been liquidated by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
                 }
-                // If it's not a blockhash not found, we continue it's treated later
             }
         }
     };

--- a/src/handlers/liquidate_long.rs
+++ b/src/handlers/liquidate_long.rs
@@ -203,6 +203,14 @@ pub async fn liquidate_long(
         duration.num_milliseconds()
     );
 
+    if duration.num_milliseconds() > 150 {
+        log::warn!(
+            "   <> TOOK too long to liquidate LONG position {:#?} - ({} ms)",
+            position_key,
+            duration.num_milliseconds()
+        );
+    }
+
     Ok(())
 }
 

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -119,8 +119,18 @@ pub async fn liquidate_short(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been liquidated by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been liquidated by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
                 }
-                // If it's not a blockhash not found, we continue it's treated later
             }
         }
     };

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -138,7 +138,6 @@ pub async fn liquidate_short(
                         simulation_attempts,
                         e
                     );
-                    // tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -3,9 +3,9 @@ use {
         handlers::create_liquidate_short_ix, IndexedCustodiesThreadSafe, LIQUIDATE_SHORT_CU_LIMIT,
     },
     adrena_abi::{
-        liquidation_price::get_liquidation_price, main_pool::USDC_CUSTODY_ID,
-        oracle_price::OraclePrice, types::Cortex, Custody, Position, ADX_MINT, ALP_MINT,
-        SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody,
+        LeverageCheckStatus, Pool, Position, ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID,
+        SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -137,7 +137,7 @@ pub async fn liquidate_short(
                         simulation_attempts,
                         e
                     );
-                    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+                    // tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -210,6 +210,14 @@ pub async fn liquidate_short(
         duration.num_milliseconds()
     );
 
+    if duration.num_milliseconds() > 150 {
+        log::warn!(
+            "   <> TOOK too long to liquidate SHORT position {:#?} - ({} ms)",
+            position_key,
+            duration.num_milliseconds()
+        );
+    }
+
     Ok(())
 }
 

--- a/src/handlers/liquidate_short.rs
+++ b/src/handlers/liquidate_short.rs
@@ -4,12 +4,15 @@ use {
     },
     adrena_abi::{
         liquidation_price::get_liquidation_price, main_pool::USDC_CUSTODY_ID,
-        oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT, ALP_MINT,
+        oracle_price::OraclePrice, types::Cortex, Custody, Position, ADX_MINT, ALP_MINT,
         SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
+        transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -37,7 +40,7 @@ pub async fn liquidate_short(
     // check if the price has crossed the liquidation price
     if oracle_price.price >= liquidation_price {
         log::info!(
-            "Liquidation condition met for SHORT position {:#?} - Oracle Price: {}, Liquidation Price: {}",
+            "   <*> Liquidation condition met for SHORT position {:#?} - Oracle Price: {}, Liquidation Price: {}",
             position_key,
             oracle_price.price,
             liquidation_price
@@ -75,10 +78,122 @@ pub async fn liquidate_short(
         _ => None,
     };
 
+    let rpc_client = program.rpc();
     let transfer_authority_pda = adrena_abi::pda::get_transfer_authority_pda().0;
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
+    // Simulate the transaction to get the CU consumed (and check if liquidation is possible, as the calculations are slightly different)
+    // The backend base the liquidation on the position leverage, not the liquidation price
+    let tx_simulation = create_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        median_priority_fee,
+        LIQUIDATE_SHORT_CU_LIMIT as u64,
+    )
+    .await?;
+
+    let mut simulation_attempts = 0;
+    let simulation = loop {
+        match rpc_client.simulate_transaction(&tx_simulation).await {
+            Ok(simulation) => break simulation,
+            Err(e) => {
+                if e.to_string().contains("BlockhashNotFound") {
+                    simulation_attempts += 1;
+                    log::warn!(
+                        "   <> Simulation attempt {} failed with error: {:?} - Retrying...",
+                        simulation_attempts,
+                        e
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+                    if simulation_attempts >= 25 {
+                        return Err(backoff::Error::transient(e.into()));
+                    }
+                }
+                // If it's not a blockhash not found, we continue it's treated later
+            }
+        }
+    };
+
+    let simulated_cu = simulation.value.units_consumed.unwrap_or(0);
+
+    if simulated_cu == 0 {
+        log::warn!(
+            "   <> CU consumed: {} - Simulation failed (possibly not liquidable yet(skip)",
+            simulated_cu
+        );
+        return Ok(());
+    }
+
+    // Create the actual transaction with the refined CU limit
+    let tx = create_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        median_priority_fee,
+        (simulated_cu as f64 * 1.02) as u64, // +2% for any jitter due to find_pda calls
+    )
+    .await?;
+
+    let tx_hash = rpc_client
+        .send_transaction_with_config(
+            &tx,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                max_retries: Some(0),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| {
+            log::error!("   <> Transaction sending failed with error: {:?}", e);
+            backoff::Error::transient(e.into())
+        })?;
+
+    log::info!(
+        "   <> Liquidated Short position {:#?} - TX sent: {:#?}",
+        position_key,
+        tx_hash.to_string(),
+    );
+
+    Ok(())
+}
+
+async fn create_transaction(
+    program: &Program<Arc<Keypair>>,
+    position_key: &Pubkey,
+    position: &Position,
+    receiving_account: Pubkey,
+    transfer_authority_pda: Pubkey,
+    lm_staking: Pubkey,
+    lp_staking: Pubkey,
+    cortex: &Cortex,
+    user_profile: Option<Pubkey>,
+    staking_reward_token_custody: &Custody,
+    custody: &Custody,
+    collateral_custody: &Custody,
+    median_priority_fee: u64,
+    compute_unit_limit: u64,
+) -> Result<Transaction, backoff::Error<anyhow::Error>> {
     let (liquidate_short_ix, liquidate_short_accounts) = create_liquidate_short_ix(
         &program.payer(),
         position_key,
@@ -100,41 +215,16 @@ pub async fn liquidate_short(
             median_priority_fee,
         ))
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            LIQUIDATE_SHORT_CU_LIMIT,
+            compute_unit_limit as u32,
         ))
         .args(liquidate_short_ix)
         .accounts(liquidate_short_accounts)
         .signed_transaction()
         .await
         .map_err(|e| {
-            log::error!("Transaction generation failed with error: {:?}", e);
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
-    let rpc_client = program.rpc();
-
-    let tx_hash = rpc_client
-        .send_transaction_with_config(
-            &tx,
-            RpcSendTransactionConfig {
-                skip_preflight: true,
-                max_retries: Some(0),
-                ..Default::default()
-            },
-        )
-        .await
-        .map_err(|e| {
-            log::error!("Transaction sending failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })?;
-
-    log::info!(
-        "Liquidated Short position {:#?} - TX sent: {:#?}",
-        position_key,
-        tx_hash.to_string(),
-    );
-
-    // TODO wait for confirmation and retry if needed
-
-    Ok(())
+    Ok(tx)
 }

--- a/src/handlers/sl_long.rs
+++ b/src/handlers/sl_long.rs
@@ -26,7 +26,7 @@ pub async fn sl_long(
     // check if the price has crossed the SL
     if oracle_price.price <= position.stop_loss_limit_price {
         log::info!(
-            "SL condition met for LONG position {:#?} - Price: {}",
+            "   <*> SL condition met for LONG position {:#?} - Price: {}",
             position_key,
             oracle_price.price
         );
@@ -55,7 +55,7 @@ pub async fn sl_long(
 
     let user_profile_pda = get_user_profile_pda(&position.owner).0;
     // Fetch the user profile account
-    let user_profile_account = program.rpc().get_account(&user_profile_pda).await.ok(); // Convert Result to Option, None if error
+    let user_profile_account = program.rpc().get_account(&user_profile_pda).await.ok();
 
     // Check if the user profile exists (owned by the Adrena program)
     let user_profile = match user_profile_account {
@@ -95,7 +95,7 @@ pub async fn sl_long(
         .signed_transaction()
         .await
         .map_err(|e| {
-            log::error!("Transaction generation failed with error: {:?}", e);
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
@@ -112,12 +112,12 @@ pub async fn sl_long(
         )
         .await
         .map_err(|e| {
-            log::error!("Transaction sending failed with error: {:?}", e);
+            log::error!("   <> Transaction sending failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
     log::info!(
-        "SL Long for position {:#?} - TX sent: {:#?}",
+        "   <> SL Long for position {:#?} - TX sent: {:#?}",
         position_key,
         tx_hash.to_string(),
     );

--- a/src/handlers/sl_long.rs
+++ b/src/handlers/sl_long.rs
@@ -100,6 +100,14 @@ pub async fn sl_long(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been closed by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been closed by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
                 } else {
                     log::error!("   <> Simulation failed with error: {:?}", e);
                     return Ok(());

--- a/src/handlers/sl_long.rs
+++ b/src/handlers/sl_long.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        handlers::create_close_position_long_ix, IndexedCustodiesThreadSafe,
-        CLOSE_POSITION_LONG_CU_LIMIT,
-    },
+    crate::{handlers::create_close_position_long_ix, IndexedCustodiesThreadSafe},
     adrena_abi::{
         get_transfer_authority_pda, get_user_profile_pda, main_pool::USDC_CUSTODY_ID,
         oracle_price::OraclePrice, types::Cortex, Custody, Position, ADX_MINT, ALP_MINT,
@@ -10,7 +7,10 @@ use {
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair, transaction::Transaction},
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
+        transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -80,7 +80,7 @@ pub async fn sl_long(
         staking_reward_token_custody,
         custody,
         median_priority_fee,
-        CLOSE_POSITION_LONG_CU_LIMIT as u64,
+        500_000,
     )
     .await?;
 
@@ -139,7 +139,7 @@ pub async fn sl_long(
         staking_reward_token_custody,
         custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.02) as u64,
+        (simulated_cu as f64 * 1.05) as u64,
     )
     .await?;
 

--- a/src/handlers/sl_long.rs
+++ b/src/handlers/sl_long.rs
@@ -5,12 +5,12 @@ use {
     },
     adrena_abi::{
         get_transfer_authority_pda, get_user_profile_pda, main_pool::USDC_CUSTODY_ID,
-        oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT, ALP_MINT,
+        oracle_price::OraclePrice, types::Cortex, Custody, Position, ADX_MINT, ALP_MINT,
         SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair, transaction::Transaction},
     std::sync::Arc,
 };
 
@@ -67,8 +67,8 @@ pub async fn sl_long(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let (close_position_long_params, close_position_long_accounts) = create_close_position_long_ix(
-        &program.payer(),
+    let tx_simulation = create_sl_long_transaction(
+        program,
         position_key,
         position,
         receiving_account,
@@ -79,27 +79,61 @@ pub async fn sl_long(
         user_profile,
         staking_reward_token_custody,
         custody,
-        position.stop_loss_close_position_price,
-    );
-
-    let tx = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            median_priority_fee,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            CLOSE_POSITION_LONG_CU_LIMIT,
-        ))
-        .args(close_position_long_params)
-        .accounts(close_position_long_accounts)
-        .signed_transaction()
-        .await
-        .map_err(|e| {
-            log::error!("   <> Transaction generation failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })?;
+        median_priority_fee,
+        CLOSE_POSITION_LONG_CU_LIMIT as u64,
+    )
+    .await?;
 
     let rpc_client = program.rpc();
+    let mut simulation_attempts = 0;
+    let simulation = loop {
+        match rpc_client.simulate_transaction(&tx_simulation).await {
+            Ok(simulation) => break simulation,
+            Err(e) => {
+                if e.to_string().contains("BlockhashNotFound") {
+                    simulation_attempts += 1;
+                    log::warn!(
+                        "   <> Simulation attempt {} failed with error: {:?} - Retrying...",
+                        simulation_attempts,
+                        e
+                    );
+                    if simulation_attempts >= 25 {
+                        return Err(backoff::Error::transient(e.into()));
+                    }
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    let simulated_cu = simulation.value.units_consumed.unwrap_or(0);
+
+    if simulated_cu == 0 {
+        log::warn!(
+            "   <> CU consumed: {} - Simulation failed (possibly not executable yet)",
+            simulated_cu
+        );
+        return Ok(());
+    }
+
+    let tx = create_sl_long_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        median_priority_fee,
+        (simulated_cu as f64 * 1.02) as u64,
+    )
+    .await?;
 
     let tx_hash = rpc_client
         .send_transaction_with_config(
@@ -125,4 +159,52 @@ pub async fn sl_long(
     // TODO wait for confirmation and retry if needed
 
     Ok(())
+}
+
+async fn create_sl_long_transaction(
+    program: &Program<Arc<Keypair>>,
+    position_key: &Pubkey,
+    position: &Position,
+    receiving_account: Pubkey,
+    transfer_authority_pda: Pubkey,
+    lm_staking: Pubkey,
+    lp_staking: Pubkey,
+    cortex: &Cortex,
+    user_profile: Option<Pubkey>,
+    staking_reward_token_custody: &Custody,
+    custody: &Custody,
+    median_priority_fee: u64,
+    simulated_cu: u64,
+) -> Result<Transaction, backoff::Error<anyhow::Error>> {
+    let (close_position_long_params, close_position_long_accounts) = create_close_position_long_ix(
+        &program.payer(),
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        position.stop_loss_close_position_price,
+    );
+
+    program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+            median_priority_fee,
+        ))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            (simulated_cu as f64 * 1.02) as u32,
+        ))
+        .args(close_position_long_params)
+        .accounts(close_position_long_accounts)
+        .signed_transaction()
+        .await
+        .map_err(|e| {
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
+            backoff::Error::transient(e.into())
+        })
 }

--- a/src/handlers/sl_short.rs
+++ b/src/handlers/sl_short.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        handlers::create_ixs::create_close_position_short_ix, IndexedCustodiesThreadSafe,
-        CLOSE_POSITION_SHORT_CU_LIMIT,
-    },
+    crate::{handlers::create_ixs::create_close_position_short_ix, IndexedCustodiesThreadSafe},
     adrena_abi::{
         main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
         ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
@@ -83,7 +80,7 @@ pub async fn sl_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        CLOSE_POSITION_SHORT_CU_LIMIT as u64,
+        500_000,
     )
     .await?;
 
@@ -143,7 +140,7 @@ pub async fn sl_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.02) as u64,
+        (simulated_cu as f64 * 1.05) as u64,
     )
     .await?;
 

--- a/src/handlers/sl_short.rs
+++ b/src/handlers/sl_short.rs
@@ -22,8 +22,7 @@ pub async fn sl_short(
     cortex: &Cortex,
     median_priority_fee: u64,
 ) -> Result<(), backoff::Error<anyhow::Error>> {
-    // check if the price has crossed the SL
-    if oracle_price.price >= position.stop_loss_limit_price {
+    if position.stop_loss_reached(oracle_price.price) {
         log::info!(
             "   <*> SL condition met for SHORT position {:#?} - Price: {}",
             position_key,
@@ -66,7 +65,7 @@ pub async fn sl_short(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let tx_simulation = create_sl_short_transaction(
+    let tx_simulation = create_close_position_short_tx(
         program,
         position_key,
         position,
@@ -126,7 +125,7 @@ pub async fn sl_short(
         return Ok(());
     }
 
-    let tx = create_sl_short_transaction(
+    let tx = create_close_position_short_tx(
         program,
         position_key,
         position,
@@ -140,7 +139,7 @@ pub async fn sl_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.05) as u64,
+        (simulated_cu as f64 * 1.05) as u32,
     )
     .await?;
 
@@ -168,7 +167,7 @@ pub async fn sl_short(
     Ok(())
 }
 
-async fn create_sl_short_transaction(
+pub async fn create_close_position_short_tx(
     program: &Program<Arc<Keypair>>,
     position_key: &Pubkey,
     position: &Position,
@@ -182,7 +181,7 @@ async fn create_sl_short_transaction(
     custody: &Custody,
     collateral_custody: &Custody,
     median_priority_fee: u64,
-    simulated_cu: u64,
+    computing_units: u32,
 ) -> Result<Transaction, backoff::Error<anyhow::Error>> {
     let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
         &program.payer(),
@@ -206,7 +205,7 @@ async fn create_sl_short_transaction(
             median_priority_fee,
         ))
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            (simulated_cu as f64 * 1.02) as u32,
+            computing_units,
         ))
         .args(close_position_short_ix)
         .accounts(close_position_short_accounts)

--- a/src/handlers/sl_short.rs
+++ b/src/handlers/sl_short.rs
@@ -103,6 +103,14 @@ pub async fn sl_short(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been closed by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been closed by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
                 } else {
                     log::error!("   <> Simulation failed with error: {:?}", e);
                     return Ok(());

--- a/src/handlers/sl_short.rs
+++ b/src/handlers/sl_short.rs
@@ -25,7 +25,7 @@ pub async fn sl_short(
     // check if the price has crossed the SL
     if oracle_price.price >= position.stop_loss_limit_price {
         log::info!(
-            "SL condition met for SHORT position {:#?} - Price: {}",
+            "   <*> SL condition met for SHORT position {:#?} - Price: {}",
             position_key,
             oracle_price.price
         );
@@ -54,7 +54,7 @@ pub async fn sl_short(
 
     let user_profile_pda = adrena_abi::pda::get_user_profile_pda(&position.owner).0;
     // Fetch the user profile account
-    let user_profile_account = program.rpc().get_account(&user_profile_pda).await.ok(); // Convert Result to Option, None if error
+    let user_profile_account = program.rpc().get_account(&user_profile_pda).await.ok();
 
     // Check if the user profile exists (owned by the Adrena program)
     let user_profile = match user_profile_account {
@@ -95,7 +95,7 @@ pub async fn sl_short(
         .signed_transaction()
         .await
         .map_err(|e| {
-            log::error!("Transaction generation failed with error: {:?}", e);
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
@@ -112,12 +112,12 @@ pub async fn sl_short(
         )
         .await
         .map_err(|e| {
-            log::error!("Transaction sending failed with error: {:?}", e);
+            log::error!("   <> Transaction sending failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
     log::info!(
-        "SL Short for position {:#?} - TX sent: {:#?}",
+        "   <> SL Short for position {:#?} - TX sent: {:#?}",
         position_key,
         tx_hash.to_string(),
     );

--- a/src/handlers/sl_short.rs
+++ b/src/handlers/sl_short.rs
@@ -4,12 +4,15 @@ use {
         CLOSE_POSITION_SHORT_CU_LIMIT,
     },
     adrena_abi::{
-        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT,
-        ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
+        ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
+        transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -66,8 +69,8 @@ pub async fn sl_short(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
-        &program.payer(),
+    let tx_simulation = create_sl_short_transaction(
+        program,
         position_key,
         position,
         receiving_account,
@@ -79,27 +82,62 @@ pub async fn sl_short(
         staking_reward_token_custody,
         custody,
         collateral_custody,
-        position.stop_loss_close_position_price,
-    );
-
-    let tx = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            median_priority_fee,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            CLOSE_POSITION_SHORT_CU_LIMIT,
-        ))
-        .args(close_position_short_ix)
-        .accounts(close_position_short_accounts)
-        .signed_transaction()
-        .await
-        .map_err(|e| {
-            log::error!("   <> Transaction generation failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })?;
+        median_priority_fee,
+        CLOSE_POSITION_SHORT_CU_LIMIT as u64,
+    )
+    .await?;
 
     let rpc_client = program.rpc();
+    let mut simulation_attempts = 0;
+    let simulation = loop {
+        match rpc_client.simulate_transaction(&tx_simulation).await {
+            Ok(simulation) => break simulation,
+            Err(e) => {
+                if e.to_string().contains("BlockhashNotFound") {
+                    simulation_attempts += 1;
+                    log::warn!(
+                        "   <> Simulation attempt {} failed with error: {:?} - Retrying...",
+                        simulation_attempts,
+                        e
+                    );
+                    if simulation_attempts >= 25 {
+                        return Err(backoff::Error::transient(e.into()));
+                    }
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    let simulated_cu = simulation.value.units_consumed.unwrap_or(0);
+
+    if simulated_cu == 0 {
+        log::warn!(
+            "   <> CU consumed: {} - Simulation failed (possibly not executable yet)",
+            simulated_cu
+        );
+        return Ok(());
+    }
+
+    let tx = create_sl_short_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        median_priority_fee,
+        (simulated_cu as f64 * 1.02) as u64,
+    )
+    .await?;
 
     let tx_hash = rpc_client
         .send_transaction_with_config(
@@ -122,7 +160,55 @@ pub async fn sl_short(
         tx_hash.to_string(),
     );
 
-    // TODO wait for confirmation and retry if needed
-
     Ok(())
+}
+
+async fn create_sl_short_transaction(
+    program: &Program<Arc<Keypair>>,
+    position_key: &Pubkey,
+    position: &Position,
+    receiving_account: Pubkey,
+    transfer_authority_pda: Pubkey,
+    lm_staking: Pubkey,
+    lp_staking: Pubkey,
+    cortex: &Cortex,
+    user_profile: Option<Pubkey>,
+    staking_reward_token_custody: &Custody,
+    custody: &Custody,
+    collateral_custody: &Custody,
+    median_priority_fee: u64,
+    simulated_cu: u64,
+) -> Result<Transaction, backoff::Error<anyhow::Error>> {
+    let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
+        &program.payer(),
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        position.stop_loss_close_position_price,
+    );
+
+    program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+            median_priority_fee,
+        ))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            (simulated_cu as f64 * 1.02) as u32,
+        ))
+        .args(close_position_short_ix)
+        .accounts(close_position_short_accounts)
+        .signed_transaction()
+        .await
+        .map_err(|e| {
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
+            backoff::Error::transient(e.into())
+        })
 }

--- a/src/handlers/tp_long.rs
+++ b/src/handlers/tp_long.rs
@@ -4,12 +4,15 @@ use {
         CLOSE_POSITION_LONG_CU_LIMIT,
     },
     adrena_abi::{
-        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT,
-        ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
+        ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
+        transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -66,8 +69,8 @@ pub async fn tp_long(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let (close_position_long_ix, close_position_long_accounts) = create_close_position_long_ix(
-        &program.payer(),
+    let tx_simulation = create_tp_long_transaction(
+        program,
         position_key,
         position,
         receiving_account,
@@ -78,27 +81,61 @@ pub async fn tp_long(
         user_profile,
         staking_reward_token_custody,
         custody,
-        position.take_profit_limit_price,
-    );
-
-    let tx = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            median_priority_fee,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            CLOSE_POSITION_LONG_CU_LIMIT,
-        ))
-        .args(close_position_long_ix)
-        .accounts(close_position_long_accounts)
-        .signed_transaction()
-        .await
-        .map_err(|e| {
-            log::error!("   <> Transaction generation failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })?;
+        median_priority_fee,
+        CLOSE_POSITION_LONG_CU_LIMIT as u64,
+    )
+    .await?;
 
     let rpc_client = program.rpc();
+    let mut simulation_attempts = 0;
+    let simulation = loop {
+        match rpc_client.simulate_transaction(&tx_simulation).await {
+            Ok(simulation) => break simulation,
+            Err(e) => {
+                if e.to_string().contains("BlockhashNotFound") {
+                    simulation_attempts += 1;
+                    log::warn!(
+                        "   <> Simulation attempt {} failed with error: {:?} - Retrying...",
+                        simulation_attempts,
+                        e
+                    );
+                    if simulation_attempts >= 25 {
+                        return Err(backoff::Error::transient(e.into()));
+                    }
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    let simulated_cu = simulation.value.units_consumed.unwrap_or(0);
+
+    if simulated_cu == 0 {
+        log::warn!(
+            "   <> CU consumed: {} - Simulation failed (possibly not executable yet)",
+            simulated_cu
+        );
+        return Ok(());
+    }
+
+    let tx = create_tp_long_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        median_priority_fee,
+        (simulated_cu as f64 * 1.02) as u64,
+    )
+    .await?;
 
     let tx_hash = rpc_client
         .send_transaction_with_config(
@@ -124,4 +161,52 @@ pub async fn tp_long(
     // TODO wait for confirmation and retry if needed
 
     Ok(())
+}
+
+async fn create_tp_long_transaction(
+    program: &Program<Arc<Keypair>>,
+    position_key: &Pubkey,
+    position: &Position,
+    receiving_account: Pubkey,
+    transfer_authority_pda: Pubkey,
+    lm_staking: Pubkey,
+    lp_staking: Pubkey,
+    cortex: &Cortex,
+    user_profile: Option<Pubkey>,
+    staking_reward_token_custody: &Custody,
+    custody: &Custody,
+    median_priority_fee: u64,
+    simulated_cu: u64,
+) -> Result<Transaction, backoff::Error<anyhow::Error>> {
+    let (close_position_long_params, close_position_long_accounts) = create_close_position_long_ix(
+        &program.payer(),
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        position.take_profit_limit_price,
+    );
+
+    program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+            median_priority_fee,
+        ))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            (simulated_cu as f64 * 1.02) as u32,
+        ))
+        .args(close_position_long_params)
+        .accounts(close_position_long_accounts)
+        .signed_transaction()
+        .await
+        .map_err(|e| {
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
+            backoff::Error::transient(e.into())
+        })
 }

--- a/src/handlers/tp_long.rs
+++ b/src/handlers/tp_long.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        handlers::create_close_position_long_ix, IndexedCustodiesThreadSafe,
-        CLOSE_POSITION_LONG_CU_LIMIT,
-    },
+    crate::{handlers::create_close_position_long_ix, IndexedCustodiesThreadSafe},
     adrena_abi::{
         main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
         ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
@@ -82,7 +79,7 @@ pub async fn tp_long(
         staking_reward_token_custody,
         custody,
         median_priority_fee,
-        CLOSE_POSITION_LONG_CU_LIMIT as u64,
+        500_000,
     )
     .await?;
 
@@ -141,7 +138,7 @@ pub async fn tp_long(
         staking_reward_token_custody,
         custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.02) as u64,
+        (simulated_cu as f64 * 1.05) as u64,
     )
     .await?;
 

--- a/src/handlers/tp_long.rs
+++ b/src/handlers/tp_long.rs
@@ -102,6 +102,14 @@ pub async fn tp_long(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been closed by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been closed by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
                 } else {
                     log::error!("   <> Simulation failed with error: {:?}", e);
                     return Ok(());

--- a/src/handlers/tp_long.rs
+++ b/src/handlers/tp_long.rs
@@ -25,7 +25,7 @@ pub async fn tp_long(
     // check if the price has crossed the TP
     if oracle_price.price >= position.take_profit_limit_price {
         log::info!(
-            "TP condition met for LONG position {:#?} - Price: {}",
+            "   <*> TP condition met for LONG position {:#?} - Price: {}",
             position_key,
             oracle_price.price
         );
@@ -94,7 +94,7 @@ pub async fn tp_long(
         .signed_transaction()
         .await
         .map_err(|e| {
-            log::error!("Transaction generation failed with error: {:?}", e);
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
@@ -111,12 +111,12 @@ pub async fn tp_long(
         )
         .await
         .map_err(|e| {
-            log::error!("Transaction sending failed with error: {:?}", e);
+            log::error!("   <> Transaction sending failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
     log::info!(
-        "TP Long for position {:#?} - TX sent: {:#?}",
+        "   <> TP Long for position {:#?} - TX sent: {:#?}",
         position_key,
         tx_hash.to_string(),
     );

--- a/src/handlers/tp_short.rs
+++ b/src/handlers/tp_short.rs
@@ -25,7 +25,7 @@ pub async fn tp_short(
     // check if the price has crossed the TP
     if oracle_price.price <= position.take_profit_limit_price {
         log::info!(
-            "TP condition met for SHORT position {:#?} - Price: {}",
+            "   <*> TP condition met for SHORT position {:#?} - Price: {}",
             position_key,
             oracle_price.price
         );
@@ -96,7 +96,7 @@ pub async fn tp_short(
         .signed_transaction()
         .await
         .map_err(|e| {
-            log::error!("Transaction generation failed with error: {:?}", e);
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
@@ -113,12 +113,12 @@ pub async fn tp_short(
         )
         .await
         .map_err(|e| {
-            log::error!("Transaction sending failed with error: {:?}", e);
+            log::error!("   <> Transaction sending failed with error: {:?}", e);
             backoff::Error::transient(e.into())
         })?;
 
     log::info!(
-        "TP Short for position {:#?} - TX sent: {:#?}",
+        "   <> TP Short for position {:#?} - TX sent: {:#?}",
         position_key,
         tx_hash.to_string(),
     );

--- a/src/handlers/tp_short.rs
+++ b/src/handlers/tp_short.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        handlers::create_ixs::create_close_position_short_ix, IndexedCustodiesThreadSafe,
-        CLOSE_POSITION_SHORT_CU_LIMIT,
-    },
+    crate::{handlers::create_ixs::create_close_position_short_ix, IndexedCustodiesThreadSafe},
     adrena_abi::{
         main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
         ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
@@ -84,7 +81,7 @@ pub async fn tp_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        CLOSE_POSITION_SHORT_CU_LIMIT as u64,
+        500_000,
     )
     .await?;
 
@@ -144,7 +141,7 @@ pub async fn tp_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.02) as u64,
+        (simulated_cu as f64 * 1.05) as u64,
     )
     .await?;
 

--- a/src/handlers/tp_short.rs
+++ b/src/handlers/tp_short.rs
@@ -4,12 +4,15 @@ use {
         CLOSE_POSITION_SHORT_CU_LIMIT,
     },
     adrena_abi::{
-        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT,
-        ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
+        ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair},
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
+        transaction::Transaction,
+    },
     std::sync::Arc,
 };
 
@@ -67,8 +70,8 @@ pub async fn tp_short(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
-        &program.payer(),
+    let tx_simulation = create_tp_short_transaction(
+        program,
         position_key,
         position,
         receiving_account,
@@ -80,27 +83,62 @@ pub async fn tp_short(
         staking_reward_token_custody,
         custody,
         collateral_custody,
-        position.take_profit_limit_price,
-    );
-
-    let tx = program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            median_priority_fee,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            CLOSE_POSITION_SHORT_CU_LIMIT,
-        ))
-        .args(close_position_short_ix)
-        .accounts(close_position_short_accounts)
-        .signed_transaction()
-        .await
-        .map_err(|e| {
-            log::error!("   <> Transaction generation failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })?;
+        median_priority_fee,
+        CLOSE_POSITION_SHORT_CU_LIMIT as u64,
+    )
+    .await?;
 
     let rpc_client = program.rpc();
+    let mut simulation_attempts = 0;
+    let simulation = loop {
+        match rpc_client.simulate_transaction(&tx_simulation).await {
+            Ok(simulation) => break simulation,
+            Err(e) => {
+                if e.to_string().contains("BlockhashNotFound") {
+                    simulation_attempts += 1;
+                    log::warn!(
+                        "   <> Simulation attempt {} failed with error: {:?} - Retrying...",
+                        simulation_attempts,
+                        e
+                    );
+                    if simulation_attempts >= 25 {
+                        return Err(backoff::Error::transient(e.into()));
+                    }
+                } else {
+                    log::error!("   <> Simulation failed with error: {:?}", e);
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    let simulated_cu = simulation.value.units_consumed.unwrap_or(0);
+
+    if simulated_cu == 0 {
+        log::warn!(
+            "   <> CU consumed: {} - Simulation failed (possibly not executable yet)",
+            simulated_cu
+        );
+        return Ok(());
+    }
+
+    let tx = create_tp_short_transaction(
+        program,
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        median_priority_fee,
+        (simulated_cu as f64 * 1.02) as u64,
+    )
+    .await?;
 
     let tx_hash = rpc_client
         .send_transaction_with_config(
@@ -122,7 +160,56 @@ pub async fn tp_short(
         position_key,
         tx_hash.to_string(),
     );
-    // TODO wait for confirmation and retry if needed
 
     Ok(())
+}
+
+async fn create_tp_short_transaction(
+    program: &Program<Arc<Keypair>>,
+    position_key: &Pubkey,
+    position: &Position,
+    receiving_account: Pubkey,
+    transfer_authority_pda: Pubkey,
+    lm_staking: Pubkey,
+    lp_staking: Pubkey,
+    cortex: &Cortex,
+    user_profile: Option<Pubkey>,
+    staking_reward_token_custody: &Custody,
+    custody: &Custody,
+    collateral_custody: &Custody,
+    median_priority_fee: u64,
+    simulated_cu: u64,
+) -> Result<Transaction, backoff::Error<anyhow::Error>> {
+    let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
+        &program.payer(),
+        position_key,
+        position,
+        receiving_account,
+        transfer_authority_pda,
+        lm_staking,
+        lp_staking,
+        cortex,
+        user_profile,
+        staking_reward_token_custody,
+        custody,
+        collateral_custody,
+        position.take_profit_limit_price,
+    );
+
+    program
+        .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
+            median_priority_fee,
+        ))
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            (simulated_cu as f64 * 1.02) as u32,
+        ))
+        .args(close_position_short_ix)
+        .accounts(close_position_short_accounts)
+        .signed_transaction()
+        .await
+        .map_err(|e| {
+            log::error!("   <> Transaction generation failed with error: {:?}", e);
+            backoff::Error::transient(e.into())
+        })
 }

--- a/src/handlers/tp_short.rs
+++ b/src/handlers/tp_short.rs
@@ -104,6 +104,14 @@ pub async fn tp_short(
                     if simulation_attempts >= 25 {
                         return Err(backoff::Error::transient(e.into()));
                     }
+                } else if e.to_string().contains("AccountOwnedByWrongProgram") {
+                    // This means the position has already been closed by another instance
+
+                    log::info!(
+                        "   <> Position {:#?} has already been closed by another instance - Skipping",
+                        position_key
+                    );
+                    return Ok(());
                 } else {
                     log::error!("   <> Simulation failed with error: {:?}", e);
                     return Ok(());

--- a/src/handlers/tp_short.rs
+++ b/src/handlers/tp_short.rs
@@ -1,15 +1,12 @@
 use {
-    crate::{handlers::create_ixs::create_close_position_short_ix, IndexedCustodiesThreadSafe},
+    crate::{handlers::sl_short::create_close_position_short_tx, IndexedCustodiesThreadSafe},
     adrena_abi::{
-        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Custody, Position,
-        ADX_MINT, ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
+        main_pool::USDC_CUSTODY_ID, oracle_price::OraclePrice, types::Cortex, Position, ADX_MINT,
+        ALP_MINT, SPL_ASSOCIATED_TOKEN_PROGRAM_ID, SPL_TOKEN_PROGRAM_ID,
     },
     anchor_client::Program,
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::{
-        compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair,
-        transaction::Transaction,
-    },
+    solana_sdk::{pubkey::Pubkey, signature::Keypair},
     std::sync::Arc,
 };
 
@@ -22,8 +19,7 @@ pub async fn tp_short(
     cortex: &Cortex,
     median_priority_fee: u64,
 ) -> Result<(), backoff::Error<anyhow::Error>> {
-    // check if the price has crossed the TP
-    if oracle_price.price <= position.take_profit_limit_price {
+    if position.take_profit_reached(oracle_price.price) {
         log::info!(
             "   <*> TP condition met for SHORT position {:#?} - Price: {}",
             position_key,
@@ -67,7 +63,7 @@ pub async fn tp_short(
     let lm_staking = adrena_abi::pda::get_staking_pda(&ADX_MINT).0;
     let lp_staking = adrena_abi::pda::get_staking_pda(&ALP_MINT).0;
 
-    let tx_simulation = create_tp_short_transaction(
+    let tx_simulation = create_close_position_short_tx(
         program,
         position_key,
         position,
@@ -127,7 +123,7 @@ pub async fn tp_short(
         return Ok(());
     }
 
-    let tx = create_tp_short_transaction(
+    let tx = create_close_position_short_tx(
         program,
         position_key,
         position,
@@ -141,7 +137,7 @@ pub async fn tp_short(
         custody,
         collateral_custody,
         median_priority_fee,
-        (simulated_cu as f64 * 1.05) as u64,
+        (simulated_cu as f64 * 1.05) as u32,
     )
     .await?;
 
@@ -167,54 +163,4 @@ pub async fn tp_short(
     );
 
     Ok(())
-}
-
-async fn create_tp_short_transaction(
-    program: &Program<Arc<Keypair>>,
-    position_key: &Pubkey,
-    position: &Position,
-    receiving_account: Pubkey,
-    transfer_authority_pda: Pubkey,
-    lm_staking: Pubkey,
-    lp_staking: Pubkey,
-    cortex: &Cortex,
-    user_profile: Option<Pubkey>,
-    staking_reward_token_custody: &Custody,
-    custody: &Custody,
-    collateral_custody: &Custody,
-    median_priority_fee: u64,
-    simulated_cu: u64,
-) -> Result<Transaction, backoff::Error<anyhow::Error>> {
-    let (close_position_short_ix, close_position_short_accounts) = create_close_position_short_ix(
-        &program.payer(),
-        position_key,
-        position,
-        receiving_account,
-        transfer_authority_pda,
-        lm_staking,
-        lp_staking,
-        cortex,
-        user_profile,
-        staking_reward_token_custody,
-        custody,
-        collateral_custody,
-        position.take_profit_limit_price,
-    );
-
-    program
-        .request()
-        .instruction(ComputeBudgetInstruction::set_compute_unit_price(
-            median_priority_fee,
-        ))
-        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            (simulated_cu as f64 * 1.02) as u32,
-        ))
-        .args(close_position_short_ix)
-        .accounts(close_position_short_accounts)
-        .signed_transaction()
-        .await
-        .map_err(|e| {
-            log::error!("   <> Transaction generation failed with error: {:?}", e);
-            backoff::Error::transient(e.into())
-        })
 }


### PR DESCRIPTION
+ add simulation for liquidate as the calculation isn't iso with the backend (cause a lot of false positive who drain SOLs)
+ update logs